### PR TITLE
feat: reimplement read-action-input in bash instead of node

### DIFF
--- a/read-action-input
+++ b/read-action-input
@@ -1,13 +1,10 @@
-#!/usr/bin/env node
-// helper script for printing kebab-cased env vars.
-// e.g., "foo-bar" -> "INPUT_FOO-BAR".
-//
-// This does not need to be implemented in nodejs,
-// but reimplementing this in sh is hard.
+#!/usr/bin/env bash
+# helper script for printing kebab-cased env vars.
+# e.g., "foo-bar" -> "INPUT_FOO-BAR".
 
-const arg = process.argv[2]; // Equates to "$1" in sh
-const k = "INPUT_" + arg.toUpperCase();
-const v = process.env[k];
-if ( v !== undefined ) {
-  console.log(v);
-}
+arg=INPUT_${1^^}
+while IFS= read -r -d '' var; do
+  [[ $var = "$arg"=* ]] || continue
+  echo "${var#"${arg}="}"
+  break
+done </proc/self/environ

--- a/read-action-input
+++ b/read-action-input
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # helper script for printing kebab-cased env vars.
 # e.g., "foo-bar" -> "INPUT_FOO-BAR".
+set -eu -o pipefail 
 
 arg=INPUT_${1^^}
 while IFS= read -r -d '' var; do


### PR DESCRIPTION
This PR reimplements the utility function `read-action-input` in `bash` instead of `node`