### PR TITLE
Do not extract cache on job failure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,11 @@ inputs:
   skip-extraction:
     default: "false"
     description: "Skip the extraction of the cache from the docker container"
+  save-always:
+    default: "false"
+    description: "Run the post step to save the cache even if another step before fails"
 runs:
   using: 'node20'
   main: 'dist/index.js'
   post: 'dist/index.js'
+  post-if: 'success() || github.event.inputs.save-always'


### PR DESCRIPTION
# Motivation

Currently, the cache is _always_ extracted from the build. This is likely unnecessary if the build fails.

This PR skips the extraction step if the workflow job fails unless the new `save-always` input parameter is set to `true`. This mirrors the behavior of the official [`actions/cache`](https://github.com/actions/cache) action which, by default, does not upload the cache if the workflow job fails.

The current set of inputs does not allow to replicate this behavior: `skip-extraction` cannot be used since `success()` or `failure()` cannot look ahead (and cannot be used for action inputs).

_Note:_ This change is breaking as it changes previous behavior. This could be prevented by using a different approach than `actions/cache` and having the user explicitly set `skip-extraction-on-failure: true`, changing the `post-if` condition to `success() || github.event.inputs.skip-extraction-on-failure == 'false'`. I would personally prefer the change in this PR though as it seems more logical.