### PR TITLE
chore: update node runtime from node20 to node24

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - uses: pnpm/action-setup@v4
 

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
     default: ""
     description: "The name of the buildx builder to use. If not specified, the currently active builder is used."
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
   post: 'dist/index.js'
   post-if: 'success() || github.event.inputs.save-always'


### PR DESCRIPTION
This PR addresses [#65](https://github.com/reproducible-containers/buildkit-cache-dance/issues/65) by updating the GitHub Actions node runtime from `node20` to `node24` to resolve the deprecation warning.

A previous attempt was made in [#63](https://github.com/reproducible-containers/buildkit-cache-dance/pull/63), but it has been stalled due to a missing DCO sign-off. 

This PR provides a mergeable alternative.
